### PR TITLE
cuallee version updated

### DIFF
--- a/pipelines/aws_glue_datarag_config.md
+++ b/pipelines/aws_glue_datarag_config.md
@@ -2,7 +2,7 @@
 
 | Key | Value | Description |
 | --- | --- | --- |
-| `--additional-python-modules` | `cuallee==0.7.1` | Required Python package for data quality checks |
+| `--additional-python-modules` | `cuallee==0.15.2` | Required Python package for data quality checks |
 | `--datalake-formats` | `delta` | Enables Delta Lake format support |
 | `--datarag_path` | `<your-bucket-name>/path_to_datarag/` | S3 path for DataRAG storage (replace placeholder) |
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated package version for `cuallee` from `0.7.1` to `0.15.2` in AWS Glue configuration documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->